### PR TITLE
[DISCO-2194] Fix grunt write

### DIFF
--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -60,7 +60,7 @@ var buildHashMapping = function(grunt, options) {
 
 var writeManifest = function(grunt, options, nameToHashedName) {
   grunt.log.ok('writing manifest to ' + options.manifestFile);
-  grunt.file.write(options.manifestFile, options.manifestName + " = " + JSON.stringify(nameToHashedName, null, "  ") + ";", options.encoding);
+  grunt.file.write(options.manifestFile, options.manifestName + " = " + JSON.stringify(nameToHashedName, null, "  ") + ";", { encoding: options.encoding });
 };
 
 exports.hashAndSub = function(grunt, options) { //files, out, encoding, fileNameFormat) {


### PR DESCRIPTION
In https://paperlesspost.atlassian.net/browse/DISCO-2194,

We want to make sure that writing a manifest.js will work. While it might not actually be necessary for prod, the reason why it's failing is because we want to upgrade the version that we're using for grunt, and we should do the same to its dependencies too. 

As of Grunt V1, they want an encoding to be in an object instead of its own argument by itself.